### PR TITLE
Use ROCm 4.3.0

### DIFF
--- a/tools/test_runner.sh
+++ b/tools/test_runner.sh
@@ -9,7 +9,7 @@ echo "Host: $(hostname) [${GPU_MODEL}]"
 echo "Workdir: $(pwd)"
 
 echo "Sourcing env vars"
-. ~/CuPy_Team/rocm-4.2.0/profile
+. ~/CuPy_Team/rocm-4.3.0/profile
 
 echo "Setting up Python env"
 pyenv local rocm-ci


### PR DESCRIPTION
Naively updated the path to the file for env vars. Would you make `CuPy_Team/rocm-4.3.0/profile`? Or now that we can use older ROCm versions on our server, env vars relative to `/opt/rocm` would be enough for the future.
